### PR TITLE
Connect refusal test fails on AIX

### DIFF
--- a/src/libmongoc/src/mongoc/mongoc-socket.c
+++ b/src/libmongoc/src/mongoc/mongoc-socket.c
@@ -348,6 +348,11 @@ mongoc_socket_poll (mongoc_socket_poll_t *sds, /* IN */
    ret = poll (pfds, nsds, timeout);
    for (i = 0; i < nsds; i++) {
       sds[i].revents = pfds[i].revents;
+#if defined(_AIX)
+      if (sds[i].socket->errno_ == ECONNREFUSED) {
+         sds[i].revents |= POLLHUP;
+      }
+#endif
    }
 
    bson_free (pfds);


### PR DESCRIPTION
The connect_refusal test fails on AIX.

The test is expecting to get POLLHUP back in the revents field from the poll request. However, AIX does not return POLLHUP, it returns POLLOUT. AIX does not know about POLLHUP and POLLERR in user space.

This code permits to return POLLHUP when needed (automatically made on Linux, manually with this code on AIX).

Tested on mongo-c-driver 1.15, with GCC 8.3, on AIX 6.1. It corrects the test and permit to have the right behavior.